### PR TITLE
$ref and allOf property support

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -144,19 +144,20 @@
    */
   var defaults = function(schema, definitions) {
 
-    if (typeof schema['allOf'] !== 'undefined') {
-      var mergedItem = mergeAllOf(schema['allOf'], definitions);
-      return defaults(mergedItem, definitions);
-    }
-
-    if (typeof schema['$ref'] !== 'undefined') {
-      var reference = getLocalRef(schema['$ref'], definitions);
-      return defaults(reference, definitions);
-    }
 
     if (typeof schema['default'] !== 'undefined') {
 
       return schema['default'];
+
+    } else if (typeof schema['allOf'] !== 'undefined') {
+
+      var mergedItem = mergeAllOf(schema['allOf'], definitions);
+      return defaults(mergedItem, definitions);
+
+    } else if (typeof schema['$ref'] !== 'undefined') {
+
+      var reference = getLocalRef(schema['$ref'], definitions);
+      return defaults(reference, definitions);
 
     } else if (schema.type === 'object') {
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -25,7 +25,134 @@
 
   'use strict';
 
-  var defaults = function(schema) {
+  /**
+   * check whether item is plain object
+   * @param {*} item
+   * @return {Boolean}
+   */
+  var isObject = function (item) {
+    return typeof item === 'object' && item.toString() === {}.toString();
+  };
+
+  /**
+   * deep object clone
+   *
+   * @param {Object} source
+   * @return {Object}
+   */
+  var clone = function (source) {
+    var target = {};
+    for (var key in source) {
+      if (source.hasOwnProperty(key)) {
+        if (isObject(source[key])) {
+          target[key] = clone(source[key]);
+        } else {
+          target[key] = source[key];
+        }
+
+      }
+    }
+    return target;
+  };
+
+  /**
+   * returns a result of deep merge of two objects
+   *
+   * @param {Object} target
+   * @param {Object} source
+   * @return {Object}
+   */
+  var merge = function (target, source) {
+    target = clone(target);
+
+    for (var key in source) {
+      if (source.hasOwnProperty(key)) {
+        if (isObject(target[key]) && isObject(source[key])) {
+          target[key] = merge(target[key], source[key]);
+        } else {
+          target[key] = source[key];
+        }
+
+      }
+    }
+    return target;
+  };
+
+
+  /**
+   * get object by reference. works only with local references that points on
+   * definitions object
+   *
+   * @param {String} path
+   * @param {Object} definitions
+   * @return {Object}
+   */
+  var getLocalRef = function (path, definitions) {
+    path = path.replace(/^#\/definitions\//, '').split('/');
+
+    var find = function (path, root) {
+      var key = path.shift();
+      if (!root[key]) {
+        return {};
+      } else if(!path.length) {
+        return root[key];
+      } else {
+        return find(path, root[key]);
+      }
+    };
+
+    var result = find(path, definitions);
+
+    if (!isObject(result)) {
+      return result;
+    }
+    return clone(result);
+  };
+
+
+  /**
+   * merge list of objects from allOf properties
+   * if some of objects contains $ref field extracts this reference and merge it
+   *
+   * @param {Array} allOfList
+   * @param {Object} definitions
+   * @return {Object}
+   */
+  var mergeAllOf = function (allOfList, definitions) {
+    var length = allOfList.length,
+      index = -1,
+      result = {};
+
+    while (++index < length) {
+      var item = allOfList[index];
+
+      item = (typeof item['$ref'] !== 'undefined') ? getLocalRef(item['$ref'], definitions) : item;
+
+      result = merge(result, item);
+    }
+
+    return result;
+  };
+
+
+  /**
+   * returns a object that built with default values from json schema
+   *
+   * @param {Object} schema
+   * @param {Object} definitions
+   * @return {Object}
+   */
+  var defaults = function(schema, definitions) {
+
+    if (typeof schema['allOf'] !== 'undefined') {
+      var mergedItem = mergeAllOf(schema['allOf'], definitions);
+      return defaults(mergedItem, definitions);
+    }
+
+    if (typeof schema['$ref'] !== 'undefined') {
+      var reference = getLocalRef(schema['$ref'], definitions);
+      return defaults(reference, definitions);
+    }
 
     if (typeof schema['default'] !== 'undefined') {
 
@@ -37,7 +164,7 @@
 
       for (var key in schema.properties) {
         if (schema.properties.hasOwnProperty(key)) {
-          schema.properties[key] = defaults(schema.properties[key]);
+          schema.properties[key] = defaults(schema.properties[key], definitions);
 
           if (typeof schema.properties[key] === 'undefined') {
             delete schema.properties[key];
@@ -50,12 +177,28 @@
     } else if (schema.type === 'array') {
 
       if (!schema.items) { return []; }
-      return [defaults(schema.items)];
+      return [defaults(schema.items, definitions)];
 
     }
 
   };
 
-  return defaults;
+  /**
+   * main function
+   *
+   * @param {Object} schema
+   * @param {Object|undefined} definitions
+   * @return {Object}
+   */
+  return function (schema, definitions) {
+
+    if (typeof definitions === 'undefined') {
+      definitions = schema.definitions || {};
+    } else if (isObject(schema.definitions)) {
+      definitions = merge(definitions, schema.definitions);
+    }
+
+    return defaults(clone(schema), definitions);
+  };
 
 }));

--- a/test/defaultsSpec.js
+++ b/test/defaultsSpec.js
@@ -183,4 +183,161 @@ describe("defaults", function() {
     });
   });
 
+  it('returns defaults if they are present in reference', function () {
+    expect(defaults({
+      "type": "object",
+      "properties": {
+        "per_page": {
+          "$ref": "#/definitions/per_page"
+        },
+        "sort": {
+          "type": "string"
+        }
+      },
+      "definitions": {
+        "per_page": {
+          "type": "integer",
+          "default": 30
+        }
+      }
+    })).toEqual({
+      per_page: 30
+    });
+  });
+
+  it('should not throw exception if reference is not correct', function () {
+    expect(defaults({
+      "type": "object",
+      "properties": {
+        "per_page": {
+          "$ref": "#/definitions/page_per"
+        },
+        "sort": {
+          "type": "string"
+        }
+      },
+      "definitions": {
+        "per_page": {
+          "type": "integer",
+          "default": 30
+        }
+      }
+    })).toEqual({});
+  });
+
+  it('returns defaults if they are present in nested reference', function () {
+    expect(defaults({
+      "type": "object",
+      "properties": {
+        "foo": {
+          "$ref": "#/definitions/foo"
+        },
+        "sort": {
+          "type": "string"
+        }
+      },
+      "definitions": {
+        "foo": {
+          "type": "object",
+          "properties": {
+            "per_page": {
+              "$ref": "#/definitions/per_page"
+            }
+          }
+        },
+        "per_page": {
+          "type": "integer",
+          "default": 30
+        }
+      }
+    })).toEqual({
+      foo: {
+        per_page: 30
+      }
+    });
+  });
+  
+  it('should merge objects from "allOf" list and extract defaults from result object', function () {
+    expect(defaults({
+      "type": "object",
+      "properties": {
+        "per_page": {
+          "$ref": "#/definitions/per_page"
+        },
+        "per_page_big": {
+          "allOf": [
+            {"$ref": "#/definitions/per_page"},
+            {"default": 50}
+          ]
+
+        },
+        "sort": {
+          "type": "string"
+        }
+      },
+      "definitions": {
+        "per_page": {
+          "type": "integer",
+          "default": 30
+        }
+      }
+    })).toEqual({
+      per_page: 30,
+      per_page_big: 50
+    });
+
+    var res = defaults({
+      "type": "object",
+      "properties": {
+        "farewell_to_arms": {
+          "allOf": [
+            {"$ref": "#/definitions/book"},
+            {"properties": {
+              "price": {
+                "default": 30
+              }
+            }}
+          ]
+        },
+        "for_whom_the_bell_tolls": {
+          "allOf": [
+            {"$ref": "#/definitions/book"},
+            {"properties": {
+              "price": {
+                "default": 100
+              }
+            }}
+          ]
+        }
+      },
+      "definitions": {
+        "book": {
+          "type": "object",
+          "properties": {
+            "author": {
+              "type": "string",
+              "default": "Hemingway"
+            },
+            "price": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        }
+      }
+    });
+
+    expect(res).toEqual({
+      farewell_to_arms: {
+        author: "Hemingway",
+        price: 30
+      },
+      for_whom_the_bell_tolls: {
+        author: "Hemingway",
+        price: 100
+      }
+    });
+
+  });
+
 });


### PR DESCRIPTION
Implementation of local reference and allOf lists that allows to create quite complex json-schema files without code doubling. Some examples you can find in unit tests