### PR TITLE
Array nesting

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -165,7 +165,21 @@
     } else if (schema.type === 'array') {
 
       if (!schema.items) { return []; }
-      return [defaults(schema.items, definitions)];
+      
+      // minimum item count
+      var ct = schema.minItems || 0;
+
+      // tuple-typed arrays
+      if (schema.items.constructor === Array) {
+        return schema.items.slice(0, ct).map(function (item) {
+          return defaults(item, definitions);
+        });
+      }
+
+      // object-typed arrays
+      return Array.apply(0, Array(ct)).map(function (item) {
+        return defaults(schema.items, definitions);
+      });
 
     }
 


### PR DESCRIPTION
I ran into an issue where a schema of the form:

```json
{
  "type": "array",
  "items": {
    "type": "string"
  }
}
```

produced a default object of form `[undefined]` which was undesirable for my purposes. 

I updated handling of array types without an explicit "default" property to instead use "minItems" (if applicable) and recurse into the array sub-schema(s). It handles both tuple-typed (http://spacetelescope.github.io/understanding-json-schema/reference/array.html#tuple-validation) and object-typed arrays.

Now, the schema above should produce `[]`

Additionally, the following schema:

```json
{
  "type": "array",
  "items": [
    {
      "type": "string",
      "default": "xyz"
    },
    {
      "type": "number"
    }
  ],
  "minItems": 1
}
```

should produce `["xyz"]` instead of `[undefined]`

(This change can still produce "undefined" items, but only if minItems forces use of sub-schemas without a default)

Lastly, I'm not set up to run the tests so I haven't added any. Apologies about that.